### PR TITLE
envelope: unify `payload` language

### DIFF
--- a/envelope.proto
+++ b/envelope.proto
@@ -13,9 +13,9 @@ message Envelope {
   string payloadType = 2;
 
   // Signature over:
-  //     PAE(type, body)
+  //     PAE(type, payload)
   // Where PAE is defined as:
-  // PAE(type, body) = "DSSEv1" + SP + LEN(type) + SP + type + SP + LEN(body) + SP + body
+  // PAE(type, payload) = "DSSEv1" + SP + LEN(type) + SP + type + SP + LEN(payload) + SP + payload
   // +               = concatenation
   // SP              = ASCII space [0x20]
   // "DSSEv1"        = ASCII [0x44, 0x53, 0x53, 0x45, 0x76, 0x31]


### PR DESCRIPTION
For consistency with changes made to Sigstore's protobuf-specs.