### PR TITLE
List DSSE maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,16 @@
+# DSSE Maintainers
+
+This file lists, in no particular order, the maintainers of the DSSE
+specification, their GitHub username, and their affiliation.
+
+| Name | GitHub Username | Affiliation |
+|------|-----------------|-------------|
+| Justin Cappos | @JustinCappos | New York University |
+| Santiago Torres-Arias | @SantiagoTorres | Purdue University |
+| Mark Lodato | @MarkLodato | Google |
+| Tom Hennen | @TomHennen | Google |
+| Trishank Karthik Kuppusamy | @trishankatdatadog | Datadog |
+| Aditya Sirish A Yelgundhalli | @adityasaky | New York University |
+| Marina Moore | @mnm678 | New York University |
+| Joshua Lock | @joshuagl | Verizon |
+| Lukas Pühringer | @lukpueh | New York University |


### PR DESCRIPTION
Addresses #57 

The list of maintainers needs to be iterated on / confirmed by everyone. I've currently listed the folks everyone from https://github.com/secure-systems-lab/dsse/issues/57#issuecomment-1563377650.