### PR TITLE
v1.0.2: explicitly forbid reparsing the envelope

### DIFF
--- a/envelope.md
+++ b/envelope.md
@@ -76,7 +76,7 @@ do so in the future.
 
 ## Security considerations
 
-The following advisories are relevant to all envelop formats, not just the
+The following advisories are relevant to all envelope formats, not just the
 standard JSON envelope.
 
 **Important:** Implementations MUST ensure that the same payload bytes that are

--- a/envelope.md
+++ b/envelope.md
@@ -8,12 +8,6 @@ This document describes the recommended data structure for storing DSSE
 signatures, which we call the "JSON Envelope". For the protocol/algorithm, see
 [Protocol](protocol.md).
 
-**Important:** Implementations MUST ensure that the same payload bytes that are
-verified are the ones sent to the application layer. In particular,
-implementations MUST NOT re-parse the envelope after verification to pull out
-the payload. Failure to adhere to this requirement can lead to security
-vulnerabilities.
-
 ## Standard JSON envelope
 
 See [envelope.proto](envelope.proto) for a formal schema. (Protobuf is used only
@@ -79,3 +73,14 @@ invalidating the signature:
 
 At this point we do not standardize any other encoding. If a need arises, we may
 do so in the future.
+
+## Security considerations
+
+The following advisories are relevant to all envelop formats, not just the
+standard JSON envelope.
+
+**Important:** Implementations MUST ensure that the same payload bytes that are
+verified are the ones sent to the application layer. In particular,
+implementations MUST NOT re-parse the envelope after verification to pull out
+the payload. Failure to adhere to this requirement can lead to security
+vulnerabilities.

--- a/envelope.md
+++ b/envelope.md
@@ -2,11 +2,17 @@
 
 May 10, 2024
 
-Version 1.0.1
+Version 1.0.2
 
 This document describes the recommended data structure for storing DSSE
 signatures, which we call the "JSON Envelope". For the protocol/algorithm, see
 [Protocol](protocol.md).
+
+**Important:** Implementations MUST ensure that the same payload bytes that are
+verified are the ones sent to the application layer. In particular,
+implementations MUST NOT re-parse the envelope after verification to pull out
+the payload. Failure to adhere to this requirement can lead to security
+vulnerabilities.
 
 ## Standard JSON envelope
 

--- a/protocol.md
+++ b/protocol.md
@@ -2,7 +2,7 @@
 
 May 10, 2024
 
-Version 1.0.1
+Version 1.0.2
 
 This document describes the protocol/algorithm for creating and verifying DSSE
 signatures, independent of how they are transmitted or stored. For the
@@ -102,6 +102,12 @@ To verify:
 
 Either standard or URL-safe base64 encodings are allowed. Signers may use
 either, and verifiers **MUST** accept either.
+
+**Important:** Implementations MUST ensure that the same SERIALIZED_BODY that is
+verified is the same sent to the application layer. In particular,
+implementations MUST NOT re-parse the envelope after verification to pull out
+the payload. Failure to adhere to this requirement can lead to security
+vulnerabilities.
 
 ## Multi-signature Verification
 


### PR DESCRIPTION
It is a security mistake for an implementation to parse the envelope,
verify the signature, and then re-parse the envelope to pull out the
payload, since the two different parsings could result in different
payloads.

This was already implicitly disallowed in protocol.md according to the
"to verify" instructions, but a reader who is not careful might miss
this important bit.

Now we call it out explicitly on both protocol.md and envelope.md, to
avoid any ambiguity.

Signed-off-by: Mark Lodato <lodato@google.com>
