### PR TITLE
README: update pointers to in-toto + dsse

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ See [Background](background.md) for further motivation.
 of the docs that currently reference the old format as "current", "existing",
 etc. -->
 
-*   [in-toto](https://in-toto.io) (pending implementation of [ITE-5](https://github.com/in-toto/ITE/blob/master/ITE/5/README.adoc))
+*   [in-toto](https://in-toto.io) (as described in [ITE-5](https://github.com/in-toto/ITE/blob/master/ITE/5/README.adoc), [go](https://github.com/in-toto/go-witness/tree/main/dsse), [python](https://github.com/in-toto/in-toto/blob/d8fa07f5c3c3e052319b1a9b0c06408cdf5b5185/in_toto/common_args.py#L170))
 *   [TUF](https://theupdateframework.io) (pending implementation of [TAP-17](https://github.com/theupdateframework/taps/pull/138))
 
 ## How can we use it?


### PR DESCRIPTION
We currently use DSSE in both go-witness and the python implementation, yet we hadn't updated the pointers in this repository. Though therer may be other implementations of in-toto that use DSSE, we do not need an exhaustive list.