### PR TITLE
README: add sigstore/chainguard/guac

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ etc. -->
 *   [in-toto](https://in-toto.io) (as described in [ITE-5](https://github.com/in-toto/ITE/blob/master/ITE/5/README.adoc), [go](https://github.com/in-toto/go-witness/tree/main/dsse), [python](https://github.com/in-toto/in-toto/blob/d8fa07f5c3c3e052319b1a9b0c06408cdf5b5185/in_toto/common_args.py#L170))
 *   [TUF](https://theupdateframework.io) (pending implementation of [TAP-17](https://github.com/theupdateframework/taps/pull/138))
 *   [gittuf](https://gittuf.dev) (implemented with extensions in [go](https://github.com/gittuf/gittuf/tree/main/internal/third_party/go-securesystemslib/dsse))
+*   [Sigsore](https://sigstore.dev) supports DSSE as an [entry type](https://github.com/sigstore/rekor/tree/main/pkg/types/dsse)
+*   [Chaiguard Images](https://www.chainguard.dev/unchained/reproducing-chainguards-reproducible-image-builds) use sigstore and in-toto (see above), and support DSSE
+*   [GUAC](https://guac.sh/) GUAC [supports DSSE entries](https://github.com/guacsec/guac/blob/main/pkg/ingestor/parser/dsse/parser_dsse.go) as a data type
 
 ## How can we use it?
 


### PR DESCRIPTION
Other users of DSSE exist: sigstore supports DSSE entries, which is used by chainguard images, which are signed with sigstore. GUAC parses and analyzes both ecosystems, so add it as well