### PR TITLE
Add Community Specification License (CSL 1.0) files

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,9 @@ The DSSE specification follows semantic versioning, and is released using Git
 tags. The `master` branch points to the latest release. Changes to the
 specification are submitted against the `devel` branch, and are merged into
 `master` when they are ready to be released.
+
+## Governance & Licensing
+- [Scope](governance/02-scope.md)
+- [Notices](governance/03-notices.md)
+- [License](governance/04-license.md)
+- [Governance](governance/05-governance.md)

--- a/governance/00-contributor-license-agreement.md
+++ b/governance/00-contributor-license-agreement.md
@@ -1,0 +1,18 @@
+# Community Specification Contributor License Agreement 1.0
+
+By making a Contribution to this repository, I agree to the terms of the following documents located at [https://github.com/CommunitySpecification/1.0](https://github.com/CommunitySpecification/1.0):
+
+(a) Community Specification License 1.0 (.0_Community_Specification_License-v1.md)
+
+(b) Community Specification Governance Policy 1.0 (5._Governance.md)
+
+(c) Community Specification Contribution Policy 1.0 (6._Contributing.md)
+
+(d) Community Specification Code of Conduct (8._Code_of_Conduct.md)
+
+
+In addition, for source code contributions, I certify that:
+
+(a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or (b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or (c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it. (d) I understand and agree that this working group and the contribution may be public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this agreement or the open source license(s) involved.
+
+I represent that I am legally entitled to make the grants set forth in the documents above.  If my employer(s) has rights to intellectual property that may be infringed by the materials developed by this Working Group, I represent that I have received permission to enter these agreements on behalf of that employer.

--- a/governance/00-contributor-license-agreement.md
+++ b/governance/00-contributor-license-agreement.md
@@ -2,13 +2,13 @@
 
 By making a Contribution to this repository, I agree to the terms of the following documents located at [https://github.com/CommunitySpecification/1.0](https://github.com/CommunitySpecification/1.0):
 
-(a) Community Specification License 1.0 (.0_Community_Specification_License-v1.md)
+(a) Community Specification License 1.0 ([01-community-specification-license-v1.md](https://github.com/CommunitySpecification/1.0/blob/main/01-community-specification-license-v1.md))
 
-(b) Community Specification Governance Policy 1.0 (5._Governance.md)
+(b) Community Specification Governance Policy 1.0 ([05-governance.md](https://github.com/CommunitySpecification/1.0/blob/main/05-governance.md))
 
-(c) Community Specification Contribution Policy 1.0 (6._Contributing.md)
+(c) Community Specification Contribution Policy 1.0 ([06-contributing.md](https://github.com/CommunitySpecification/1.0/blob/main/06-contributing.md))
 
-(d) Community Specification Code of Conduct (8._Code_of_Conduct.md)
+(d) Community Specification Code of Conduct ([08-code-of-conduct.md](https://github.com/CommunitySpecification/1.0/blob/main/08-code-of-conduct.md))
 
 
 In addition, for source code contributions, I certify that:

--- a/governance/01-community-specification-license-v1.md
+++ b/governance/01-community-specification-license-v1.md
@@ -1,0 +1,99 @@
+# Community Specification License 1.0
+
+**The Purpose of this License.**  This License sets forth the terms under which 1) Contributor will participate in and contribute to the development of specifications, standards, best practices, guidelines, and other similar materials under this Working Group, and 2) how the materials developed under this License may be used.  It is not intended for source code.  Capitalized terms are defined in the License's last section.
+
+**1.	Copyright.**
+
+**1.1.	Copyright License.**  Contributor grants everyone a non-sublicensable, perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as expressly stated in this License) copyright license, without any obligation for accounting, to reproduce, prepare derivative works of, publicly display, publicly perform, and distribute any materials it submits to the full extent of its copyright interest in those materials. Contributor also acknowledges that the Working Group may exercise copyright rights in the Specification, including the rights to submit the Specification to another standards organization.
+
+**1.2.	Copyright Attribution.**  As a condition, anyone exercising this copyright license must include attribution to the Working Group in any derivative work based on materials developed by the Working Group.  That attribution must include, at minimum, the material's name, version number, and source from where the materials were retrieved.  Attribution is not required for implementations of the Specification.
+
+**2.	Patents.**
+
+**2.1.	Patent License.**
+
+**2.1.1.	As a Result of Contributions.**
+
+**2.1.1.1.	As a Result of Contributions to Draft Specifications.**  Contributor grants Licensee a non-sublicensable, perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as expressly stated in this License) license to its Necessary Claims in 1) Contributor's Contributions and 2) to the Draft Specification that is within Scope as of the date of that Contribution, in both cases for Licensee's Implementation of the Draft Specification, except for those patent claims excluded by Contributor under Section 3.
+
+**2.1.1.2.	For Approved Specifications.**  Contributor grants Licensee a non-sublicensable, perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as expressly stated in this License) license to its Necessary Claims included in the Approved Specification that are within Scope for Licensee's Implementation of the Approved Specification, except for those patent claims excluded by Contributor under Section 3.
+
+**2.1.2.	Patent Grant from Licensee.**  Licensee grants each other Licensee a non-sublicensable, perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as expressly stated in this License) license to its Necessary Claims for its Implementation, except for those patent claims excluded under Section 3.
+
+**2.1.3.	Licensee Acceptance.**  The patent grants set forth in Section 2.1 extend only to Licensees that have indicated their agreement to this License as follows:
+
+**2.1.3.1.	Source Code Distributions.**  For distribution in source code, by including this License in the root directory of the source code with the Implementation;
+
+**2.1.3.2.	Non-Source Code Distributions.**  For distribution in any form other than source code, by including this License in the documentation, legal notices, via notice in the software, and/or other written materials provided with the Implementation; or
+
+**2.1.3.3.	Via Notices.md.**  By issuing pull request or commit to the Specification's repository's Notices.md file by the Implementer's authorized representative, including the Implementer's name, authorized individual and system identifier, and Specification version.
+
+**2.1.4.	Defensive Termination.**  If any Licensee files or maintains a claim in a court asserting that a Necessary Claim is infringed by an Implementation, any licenses granted under this License to the Licensee are immediately terminated unless 1) that claim is directly in response to a claim against Licensee regarding an Implementation, or 2) that claim was brought to enforce the terms of this License, including intervention in a third-party action by a Licensee.
+
+**2.1.5.	Additional Conditions.**  This License is not an assurance (i) that any of Contributor's copyrights or issued patent claims cover an Implementation of the Specification or are enforceable or (ii) that an Implementation of the Specification would not infringe intellectual property rights of any third party.
+
+**2.2.	Patent Licensing Commitment.**  In addition to the rights granted in Section 2.1, Contributor agrees to grant everyone a no charge, royalty-free license on reasonable and non-discriminatory terms to Contributor's Necessary Claims that are within Scope for:
+1) Implementations of a Draft Specification, where such license applies only to those Necessary Claims infringed by implementing Contributor's Contribution(s) included in that Draft Specification, and
+2) Implementations of the Approved Specification.
+
+This patent licensing commitment does not apply to those claims subject to Contributor's Exclusion Notice under Section 3.
+
+**2.3.	Effect of Withdrawal.**  Contributor may withdraw from the Working Group by issuing a pull request or commit providing notice of withdrawal to the Working Group repository's Notices.md file.  All of Contributor's existing commitments and obligations with respect to the Working Group up to the date of that withdrawal notice will remain in effect, but no new obligations will be incurred.
+
+**2.4.	Binding Encumbrance.**  This License is binding on any future owner, assignee, or party who has been given the right to enforce any Necessary Claims against third parties.
+
+**3.	Patent Exclusion.**
+
+**3.1.	As a Result of Contributions.**  Contributor may exclude Necessary Claims from its licensing commitments incurred under Section 2.1.1 by issuing an Exclusion Notice within 45 days of the date of that Contribution.  Contributor may not issue an Exclusion Notice for any material that has been included in a Draft Deliverable for more than 45 days prior to the date of that Contribution.
+
+**3.2.	As a Result of a Draft Specification Becoming an Approved Specification.**  Prior to the adoption of a Draft Specification as an Approved Specification, Contributor may exclude Necessary Claims from its licensing commitments under this Agreement by issuing an Exclusion Notice.  Contributor may not issue an Exclusion Notice for patents that were eligible to have been excluded pursuant to Section 3.1.
+
+**4.	Source Code License.**  Any source code developed by the Working Group is solely subject the source code license included in the Working Group's repository for that code.  If no source code license is included, the source code will be subject to the MIT License.
+
+**5.	No Other Rights.**  Except as specifically set forth in this License, no other express or implied patent, trademark, copyright, or other rights are granted under this License, including by implication, waiver, or estoppel.
+
+**6.	Antitrust Compliance.**  Contributor acknowledge that it may compete with other participants in various lines of business and that it is therefore imperative that they and their respective representatives act in a manner that does not violate any applicable antitrust laws and regulations.  This License does not restrict any Contributor from engaging in similar specification development projects. Each Contributor may design, develop, manufacture, acquire or market competitive deliverables, products, and services, and conduct its business, in whatever way it chooses.  No Contributor is obligated to announce or market any products or services.  Without limiting the generality of the foregoing, the Contributors agree not to have any discussion relating to any product pricing, methods or channels of product distribution, division of markets, allocation of customers or any other topic that should not be discussed among competitors under the auspices of the Working Group.
+
+**7.	Non-Circumvention.**  Contributor agrees that it will not intentionally take or willfully assist any third party to take any action for the purpose of circumventing any obligations under this License.
+
+**8.	Representations, Warranties and Disclaimers.**
+
+**8.1.  Representations, Warranties and Disclaimers.**  Contributor and Licensee represents and warrants that 1) it is legally entitled to grant the rights set forth in this License and 2) it will not intentionally include any third party materials in any Contribution unless those materials are available under terms that do not conflict with this License.  IN ALL OTHER RESPECTS ITS CONTRIBUTIONS ARE PROVIDED "AS IS." The entire risk as to implementing or otherwise using the Contribution or the Specification is assumed by the implementer and user. Except as stated herein, CONTRIBUTOR AND LICENSEE EXPRESSLY DISCLAIM ANY WARRANTIES (EXPRESS, IMPLIED, OR OTHERWISE), INCLUDING IMPLIED WARRANTIES OF MERCHANTABILITY, NON-INFRINGEMENT, FITNESS FOR A PARTICULAR PURPOSE, CONDITIONS OF QUALITY, OR TITLE, RELATED TO THE CONTRIBUTION OR THE SPECIFICATION.  IN NO EVENT WILL ANY PARTY BE LIABLE TO ANY OTHER PARTY FOR LOST PROFITS OR ANY FORM OF INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES OF ANY CHARACTER FROM ANY CAUSES OF ACTION OF ANY KIND WITH RESPECT TO THIS AGREEMENT, WHETHER BASED ON BREACH OF CONTRACT, TORT (INCLUDING NEGLIGENCE), OR OTHERWISE, AND WHETHER OR NOT THE OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. Any obligations regarding the transfer, successors in interest, or assignment of Necessary Claims will be satisfied if Contributor or Licensee notifies the transferee or assignee of any patent that it knows contains Necessary Claims or necessary claims under this License. Nothing in this License requires Contributor to undertake a patent search. If Contributor is 1) employed by or acting on behalf of an employer, 2) is making a Contribution under the direction or control of a third party, or 3) is making the Contribution as a consultant, contractor, or under another similar relationship with a third party, Contributor represents that they have been authorized by that party to enter into this License on its behalf.
+
+**8.2.  Distribution Disclaimer.**  Any distributions of technical information to third parties must include a notice materially similar to the following: "THESE MATERIALS ARE PROVIDED "AS IS." The Contributors and Licensees expressly disclaim any warranties (express, implied, or otherwise), including implied warranties of merchantability, non-infringement, fitness for a particular purpose, or title, related to the materials.  The entire risk as to implementing or otherwise using the materials is assumed by the implementer and user. IN NO EVENT WILL THE CONTRIBUTORS OR LICENSEES BE LIABLE TO ANY OTHER PARTY FOR LOST PROFITS OR ANY FORM OF INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES OF ANY CHARACTER FROM ANY CAUSES OF ACTION OF ANY KIND WITH RESPECT TO THIS DELIVERABLE OR ITS GOVERNING AGREEMENT, WHETHER BASED ON BREACH OF CONTRACT, TORT (INCLUDING NEGLIGENCE), OR OTHERWISE, AND WHETHER OR NOT THE OTHER MEMBER HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+
+**9.	Definitions.**
+
+**9.1.	Affiliate.** "Affiliate" means an entity that directly or indirectly Controls, is Controlled by, or is under common Control of that party.
+
+**9.2.	Approved Specification.**  "Approved Specification" means the final version and contents of any Draft Specification designated as an Approved Specification as set forth in the accompanying Governance.md file.
+
+**9.3.	Contribution.**  "Contribution" means any original work of authorship, including any modifications or additions to an existing work, that Contributor submits for inclusion in a Draft Specification, which is included in a Draft Specification or Approved Specification.
+
+**9.4.	Contributor.** "Contributor" means any person or entity that has indicated its acceptance of the License 1) by making a Contribution to the Specification, or 2) by entering into the Community Specification Contributor License Agreement for the Specification.  Contributor includes its Affiliates, assigns, agents, and successors in interest.
+
+**9.5.	Control.**  "Control" means direct or indirect control of more than 50% of the voting power to elect directors of that corporation, or for any other entity, the power to direct management of such entity.
+
+**9.6.	Draft Specification.**  "Draft Specification" means all versions of the material (except an Approved Specification) developed by this Working Group for the purpose of creating, commenting on, revising, updating, modifying, or adding to any document that is to be considered for inclusion in the Approved Specification.
+
+**9.7.	Exclusion Notice.**  "Exclusion Notice" means a written notice made by making a pull request or commit to the repository's Notices.md file that identifies patents that Contributor is excluding from its patent licensing commitments under this License.  The Exclusion Notice for issued patents and published applications must include the Draft Specification's name, patent number(s) or title and application number(s), as the case may be, for each of the issued patent(s) or pending patent application(s) that the Contributor is excluding from the royalty-free licensing commitment set forth in this License.  If an issued patent or pending patent application that may contain Necessary Claims is not set forth in the Exclusion Notice, those Necessary Claims shall continue to be subject to the licensing commitments under this License.  The Exclusion Notice for unpublished patent applications must provide either: (i) the text of the filed application; or (ii) identification of the specific part(s) of the Draft Specification whose implementation makes the excluded claim a Necessary Claim.  If (ii) is chosen, the effect of the exclusion will be limited to the identified part(s) of the Draft Specification.
+
+**9.8.	Implementation.**  "Implementation" means making, using, selling, offering for sale, importing or distributing any implementation of the Specification 1) only to the extent it implements the Specification and 2) so long as all required portions of the Specification are implemented.
+
+**9.9.	License.**  "License" means this Community Specification License.
+
+**9.10.	Licensee.**  "Licensee" means any person or entity that has indicated its acceptance of the License as set forth in Section 2.1.3.  Licensee includes its Affiliates, assigns, agents, and successors in interest.
+
+**9.11.	Necessary Claims.**  "Necessary Claims" are those patent claims, if any, that a party owns or controls, including those claims later acquired, that are necessary to implement the required portions (including the required elements of optional portions) of the Specification that are described in detail and not merely referenced in the Specification.
+
+**9.12.	Specification.**  "Specification" means a Draft Specification or Approved Specification included in the Working Group's repository subject to this License, and the version of the Specification implemented by the Licensee.
+
+**9.13.	Scope.**  "Scope" has the meaning as set forth in the accompanying Scope.md file included in this Specification's repository. Changes to Scope do not apply retroactively.  If no Scope is provided, each Contributor's Necessary Claims are limited to that Contributor's Contributions.
+
+**9.14.	Working Group.**  "Working Group" means this project to develop specifications, standards, best practices, guidelines, and other similar materials under this License.
+
+
+
+*The text of this Community Specification License is Copyright 2020 Joint Development Foundation and is licensed under the Creative Commons Attribution 4.0 International License available at https://creativecommons.org/licenses/by/4.0/.*
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/governance/02-scope.md
+++ b/governance/02-scope.md
@@ -9,7 +9,7 @@ The DSSE specification strictly defines the following mechanisms:
 *   **Pre-Authentication Encoding (PAE):** A deterministic serialization format that securely binds a payload's data to its type definition before cryptographic signing. This ensures that signatures cannot be transplanted across different metadata types.
 *   **Logical Envelope Structure:** A uniform conceptual wrapper that encapsulates the payload, its defined type descriptor, and one or more signatures. 
 *   **Format and Transport Agnosticism:** While frequently represented in JSON for web-based APIs, the DSSE logical structure and PAE mechanism are entirely format-agnostic. DSSE can be natively serialized using Protocol Buffers, CBOR, XML, or any other structured data format, provided the core envelope fields are preserved.
-*   **Multi-Signer Support:** Native architectural support for appending multiple independent signatures (and their respective key identifiers) to the exact same payload without invalidating existing signatures or requiring nested envelopes.
+*   **Multi-Signer Support:** Native architectural support for appending multiple independent signatures to the exact same payload without invalidating existing signatures or requiring nested envelopes.
 
 ## 2. Out of Scope
 

--- a/governance/02-scope.md
+++ b/governance/02-scope.md
@@ -1,30 +1,75 @@
-# DSSE Specification Scope
+# Scope
 
-This document defines the strict boundaries of the Dead Simple Signing Envelope (DSSE) specification. By aggressively limiting its scope, DSSE provides a predictable, unambiguous cryptographic component designed to integrate safely into broader software supply chain frameworks and automated tooling architectures.
+Under the Community Specification License 1.0, this document defines the scope
+of the specification the DSSE Working Group develops. The licensing
+commitments made by each contributor, including the patent commitment, apply
+to the specification as bounded by this scope.
 
 ## 1. In Scope
 
-The DSSE specification strictly defines the following mechanisms:
+The Working Group develops and maintains:
 
-*   **Pre-Authentication Encoding (PAE):** A deterministic serialization format that securely binds a payload's data to its type definition before cryptographic signing. This ensures that signatures cannot be transplanted across different metadata types.
-*   **Logical Envelope Structure:** A uniform conceptual wrapper that encapsulates the payload, its defined type descriptor, and one or more signatures. 
-*   **Signature Object Schema:** The definition of each entry in the signature set, comprising the signature value and an optional key identifier that serves as a non-authoritative hint for selecting a verification key. This schema is the designated extension point for any additional signature-level fields.
-*   **Multi-Signer Support:** Native architectural support for appending multiple independent signatures to the exact same payload without invalidating existing signatures or requiring nested envelopes.
+*   **The signing and verification protocol** ([protocol.md](../protocol.md)):
+    the definition of a signature as
+    `Sign(PAE(UTF8(PAYLOAD_TYPE), SERIALIZED_BODY))`, the Pre-Authentication
+    Encoding (PAE) that binds the payload bytes to the payload type before
+    signing, and the procedures for signing, verification, and `(t, n)`
+    multi-signature verification of a single payload.
+
+*   **The envelope data structure** ([envelope.md](../envelope.md) and
+    [envelope.proto](../envelope.proto)): the JSON envelope carrying `payload`,
+    `payloadType`, and `signatures`, together with its parsing rules for
+    required, optional, and unrecognized fields.
+
+*   **The signature object**: each entry in `signatures`, consisting of a
+    required signature value (`sig`) and an optional `keyid` — an
+    unauthenticated hint identifying which public key was used, usable only to
+    narrow the selection of keys to try.
+
+*   **Payload type identification**: conventions for the `payloadType` string
+    (Media Type or URI) that identifies both the encoding and the schema of
+    the payload.
+
+*   **Extensibility rules**: the requirement that consumers ignore
+    unrecognized envelope fields, allowing producers and future versions of
+    the specification to add fields without breaking verification.
+
+*   **Envelope encodings**: JSON is the only recommended encoding. The Working
+    Group may standardize additional encodings (such as CBOR or protobuf) in a
+    future version; until it does, other encodings are permitted by
+    applications but not specified here.
+
+*   **Test vectors** accompanying the protocol.
 
 ## 2. Out of Scope
 
-To eliminate parser vulnerabilities, mitigate cross-protocol attacks, and reduce integration friction, the following are explicitly out of scope for DSSE:
+The Working Group does not develop, and this specification does not define:
 
-*   **Payload Canonicalization:** DSSE treats all payloads as opaque byte sequences (typically base64-encoded in text formats). Normalization or canonicalization of the payload structure (e.g., JSON Canonicalization Scheme) is deliberately omitted to prevent parser-level exploits prior to signature verification.
-*   **Encryption and Confidentiality:** DSSE provides authentication and integrity only. It does not define or support mechanisms for payload encryption, privacy, or data masking.
-*   **Cryptographic Algorithm Negotiation:** The envelope does not carry self-describing algorithm headers (for example, declaring whether ECDSA or Ed25519 was used), and it defines no mechanism for negotiating algorithms between signer and verifier. Where the signature schema carries fields that approximate algorithm or key identification, such as the optional key identifier, those fields are hints for key selection only. Verifiers are expected to determine the applicable algorithms out-of-band from the established trust root or verification policy.
-*   **Key Management and Identity Binding:** Trust establishment, PKI, certificate validation, and key distribution are left to external systems (such as Sigstore, SPIFFE, or local policy engines).
-*   **Payload Semantics:** DSSE makes no assertions about the internal validity, schema, or semantic meaning of the payload itself. It only guarantees that a specific entity signed a specific sequence of bytes under a declared payload type.
+*   **Cryptographic algorithms or signature formats.** `Sign()` is an
+    arbitrary digital signature format whose details are agreed upon
+    out-of-band by the signer and verifier. The specification places no
+    restriction on the algorithm or format, carries no self-describing
+    algorithm header, and defines no negotiation mechanism.
 
-## 3. Component Interoperability
+*   **Key management, trust establishment, and identity binding.** Key
+    distribution, PKI, certificate validation, and trust roots are left to
+    external systems. The `keyid` is not a key-management mechanism: it MUST
+    NOT be used for security decisions.
 
-By maintaining these rigid boundaries, DSSE is designed to serve as a discrete, highly verifiable node within larger system architectures. It acts as a standardized interface for attestation and provenance data, allowing independent components and tools across the software supply chain to map, exchange, and verify signed metadata without requiring deep knowledge of the underlying payload structures.
+*   **Payload canonicalization.** The payload is an arbitrary byte sequence
+    (`SERIALIZED_BODY`) transmitted exactly as signed; the verifier verifies
+    it before parsing. No normalization or canonicalization scheme is defined.
 
-DSSE is also independent of any particular serialization or transport. While it is most often represented in JSON for web-based APIs, the logical envelope structure and the PAE mechanism are format-agnostic: an implementation may serialize DSSE using Protocol Buffers, CBOR, XML, or any other structured data format, provided the defined envelope fields are preserved. This independence is a property of the design rather than a component the specification defines, which is why it is described here rather than in Section 1.
+*   **Payload semantics.** The specification makes no assertions about the
+    internal validity, schema, or meaning of the payload. It guarantees only
+    that a specific sequence of bytes was signed under a declared payload
+    type.
+
+*   **Encryption and confidentiality.** The specification provides
+    authentication and integrity only.
+
+*   **Verification policy.** Which keys are trusted, which payload types are
+    supported, and the threshold `t` in `(t, n)` verification are
+    application-specific decisions made outside this specification.
 
 Any changes of Scope are not retroactive.

--- a/governance/02-scope.md
+++ b/governance/02-scope.md
@@ -8,7 +8,7 @@ The DSSE specification strictly defines the following mechanisms:
 
 *   **Pre-Authentication Encoding (PAE):** A deterministic serialization format that securely binds a payload's data to its type definition before cryptographic signing. This ensures that signatures cannot be transplanted across different metadata types.
 *   **Logical Envelope Structure:** A uniform conceptual wrapper that encapsulates the payload, its defined type descriptor, and one or more signatures. 
-*   **Format and Transport Agnosticism:** While frequently represented in JSON for web-based APIs, the DSSE logical structure and PAE mechanism are entirely format-agnostic. DSSE can be natively serialized using Protocol Buffers, CBOR, XML, or any other structured data format, provided the core envelope fields are preserved.
+*   **Signature Object Schema:** The definition of each entry in the signature set, comprising the signature value and an optional key identifier that serves as a non-authoritative hint for selecting a verification key. This schema is the designated extension point for any additional signature-level fields.
 *   **Multi-Signer Support:** Native architectural support for appending multiple independent signatures to the exact same payload without invalidating existing signatures or requiring nested envelopes.
 
 ## 2. Out of Scope
@@ -17,10 +17,14 @@ To eliminate parser vulnerabilities, mitigate cross-protocol attacks, and reduce
 
 *   **Payload Canonicalization:** DSSE treats all payloads as opaque byte sequences (typically base64-encoded in text formats). Normalization or canonicalization of the payload structure (e.g., JSON Canonicalization Scheme) is deliberately omitted to prevent parser-level exploits prior to signature verification.
 *   **Encryption and Confidentiality:** DSSE provides authentication and integrity only. It does not define or support mechanisms for payload encryption, privacy, or data masking.
-*   **Cryptographic Algorithm Negotiation:** The envelope intentionally omits self-describing cryptographic algorithm headers (e.g., specifying whether ECDSA or Ed25519 was used). Verifiers are expected to determine the correct algorithms out-of-band based on the established trust root or key identifier.
+*   **Cryptographic Algorithm Negotiation:** The envelope does not carry self-describing algorithm headers (for example, declaring whether ECDSA or Ed25519 was used), and it defines no mechanism for negotiating algorithms between signer and verifier. Where the signature schema carries fields that approximate algorithm or key identification, such as the optional key identifier, those fields are hints for key selection only. Verifiers are expected to determine the applicable algorithms out-of-band from the established trust root or verification policy.
 *   **Key Management and Identity Binding:** Trust establishment, PKI, certificate validation, and key distribution are left to external systems (such as Sigstore, SPIFFE, or local policy engines).
 *   **Payload Semantics:** DSSE makes no assertions about the internal validity, schema, or semantic meaning of the payload itself. It only guarantees that a specific entity signed a specific sequence of bytes under a declared payload type.
 
 ## 3. Component Interoperability
 
 By maintaining these rigid boundaries, DSSE is designed to serve as a discrete, highly verifiable node within larger system architectures. It acts as a standardized interface for attestation and provenance data, allowing independent components and tools across the software supply chain to map, exchange, and verify signed metadata without requiring deep knowledge of the underlying payload structures.
+
+DSSE is also independent of any particular serialization or transport. While it is most often represented in JSON for web-based APIs, the logical envelope structure and the PAE mechanism are format-agnostic: an implementation may serialize DSSE using Protocol Buffers, CBOR, XML, or any other structured data format, provided the defined envelope fields are preserved. This independence is a property of the design rather than a component the specification defines, which is why it is described here rather than in Section 1.
+
+Any changes of Scope are not retroactive.

--- a/governance/02-scope.md
+++ b/governance/02-scope.md
@@ -1,5 +1,26 @@
-# Scope
+# DSSE Specification Scope
 
-DSSE (Dead Simple Signing Envelope) standardizes a format for signing arbitrary payloads and verifying the resulting signatures. In scope: the envelope structure, the Pre-Authentication Encoding (PAE), and signature verification rules. Out of scope: key management, key distribution, and transport.
+This document defines the strict boundaries of the Dead Simple Signing Envelope (DSSE) specification. By aggressively limiting its scope, DSSE provides a predictable, unambiguous cryptographic component designed to integrate safely into broader software supply chain frameworks and automated tooling architectures.
 
-Any changes of Scope are not retroactive.
+## 1. In Scope
+
+The DSSE specification strictly defines the following mechanisms:
+
+*   **Pre-Authentication Encoding (PAE):** A deterministic serialization format that securely binds a payload's data to its type definition before cryptographic signing. This ensures that signatures cannot be transplanted across different metadata types.
+*   **Logical Envelope Structure:** A uniform conceptual wrapper that encapsulates the payload, its defined type descriptor, and one or more signatures. 
+*   **Format and Transport Agnosticism:** While frequently represented in JSON for web-based APIs, the DSSE logical structure and PAE mechanism are entirely format-agnostic. DSSE can be natively serialized using Protocol Buffers, CBOR, XML, or any other structured data format, provided the core envelope fields are preserved.
+*   **Multi-Signer Support:** Native architectural support for appending multiple independent signatures (and their respective key identifiers) to the exact same payload without invalidating existing signatures or requiring nested envelopes.
+
+## 2. Out of Scope
+
+To eliminate parser vulnerabilities, mitigate cross-protocol attacks, and reduce integration friction, the following are explicitly out of scope for DSSE:
+
+*   **Payload Canonicalization:** DSSE treats all payloads as opaque byte sequences (typically base64-encoded in text formats). Normalization or canonicalization of the payload structure (e.g., JSON Canonicalization Scheme) is deliberately omitted to prevent parser-level exploits prior to signature verification.
+*   **Encryption and Confidentiality:** DSSE provides authentication and integrity only. It does not define or support mechanisms for payload encryption, privacy, or data masking.
+*   **Cryptographic Algorithm Negotiation:** The envelope intentionally omits self-describing cryptographic algorithm headers (e.g., specifying whether ECDSA or Ed25519 was used). Verifiers are expected to determine the correct algorithms out-of-band based on the established trust root or key identifier.
+*   **Key Management and Identity Binding:** Trust establishment, PKI, certificate validation, and key distribution are left to external systems (such as Sigstore, SPIFFE, or local policy engines).
+*   **Payload Semantics:** DSSE makes no assertions about the internal validity, schema, or semantic meaning of the payload itself. It only guarantees that a specific entity signed a specific sequence of bytes under a declared payload type.
+
+## 3. Component Interoperability
+
+By maintaining these rigid boundaries, DSSE is designed to serve as a discrete, highly verifiable node within larger system architectures. It acts as a standardized interface for attestation and provenance data, allowing independent components and tools across the software supply chain to map, exchange, and verify signed metadata without requiring deep knowledge of the underlying payload structures.

--- a/governance/02-scope.md
+++ b/governance/02-scope.md
@@ -1,0 +1,5 @@
+# Scope
+
+DSSE (Dead Simple Signing Envelope) standardizes a format for signing arbitrary payloads and verifying the resulting signatures. In scope: the envelope structure, the Pre-Authentication Encoding (PAE), and signature verification rules. Out of scope: key management, key distribution, and transport.
+
+Any changes of Scope are not retroactive.

--- a/governance/03-notices.md
+++ b/governance/03-notices.md
@@ -1,0 +1,58 @@
+# Notices
+
+## Code of Conduct
+
+Contact for Code of Conduct issues or inquiries:  REAL NAME <real@email>
+
+[Ideally list two different individuals above (not a generic mailing list) as someone submitting a Code of Conduct complaint will want to know exactly who is receiving the complaint. We recommend two individuals in the case one of the individuals is the subject of or directly involved in the subject of a complaint.]
+
+
+## License Acceptance
+
+Per Community Specification License 1.0 Section 2.1.3.3, Licensees may indicate their acceptance of the Community Specification License by issuing a pull request to the Specification's repository's Notice.md file, including the Licensee's name, authorized individuals' names, and repository system identifier (e.g. GitHub ID), and specification version.
+
+A Licensee may consent to accepting the current Community Specification License version or any future version of the Community Specification License by indicating "or later" after their specification version.
+
+---------------------------------------------------------------------------------
+
+Licensee's name:
+
+Authorized individual and system identifier:
+
+Specification version:
+
+---------------------------------------------------------------------------------
+
+## Withdrawals
+
+Name of party withdrawing:
+
+Date of withdrawal:
+
+---------------------------------------------------------------------------------
+
+## Exclusions
+
+This section includes any Exclusion Notices made against a Draft Deliverable or Approved Deliverable as set forth in the Community Specification Development License. Each Exclusion Notice must include the following information:
+
+-	Name of party making the Exclusion Notice:
+
+-	Name of patent owner:
+
+-	Specification:
+
+-	Version number:
+
+**For issued patents and published patent applications:**
+
+	(i)	patent number(s) or title and application number(s), as the case may be:
+
+	(ii)	identification of the specific part(s) of the Specification whose implementation makes the excluded claim a Necessary Claim.
+
+**For unpublished patent applications must provide either:**
+
+	(i) the text of the filed application; or
+
+	(ii) identification of the specific part(s) of the Specification whose implementation makes the excluded claim a Necessary Claim.
+
+-----------------------------------------------------------------------------------------

--- a/governance/03-notices.md
+++ b/governance/03-notices.md
@@ -2,7 +2,7 @@
 
 ## Code of Conduct
 
-Contact for Code of Conduct issues or inquiries:  REAL NAME <real@email>
+Contact for Code of Conduct issues or inquiries:  Justin Cappos <jcappos@nyu.edu>, Mark Lodato (@MarkLodato), Santiago Torres-Arias (@SantiagoTorres)
 
 [Ideally list two different individuals above (not a generic mailing list) as someone submitting a Code of Conduct complaint will want to know exactly who is receiving the complaint. We recommend two individuals in the case one of the individuals is the subject of or directly involved in the subject of a complaint.]
 

--- a/governance/03-notices.md
+++ b/governance/03-notices.md
@@ -4,8 +4,6 @@
 
 Contact for Code of Conduct issues or inquiries:  Justin Cappos <jcappos@nyu.edu>, Mark Lodato (@MarkLodato), Santiago Torres-Arias (@SantiagoTorres)
 
-[Ideally list two different individuals above (not a generic mailing list) as someone submitting a Code of Conduct complaint will want to know exactly who is receiving the complaint. We recommend two individuals in the case one of the individuals is the subject of or directly involved in the subject of a complaint.]
-
 
 ## License Acceptance
 

--- a/governance/04-license.md
+++ b/governance/04-license.md
@@ -1,0 +1,11 @@
+# Licenses
+
+## Specification License
+
+Specifications in this repository are subject to the **Community Specification License 1.0** available at [https://github.com/CommunitySpecification/1.0](https://github.com/CommunitySpecification/1.0).
+
+## Source Code License
+
+If source code is included in this repository, or for sample or reference code included in the specification itself, that code is subject to the Apache-2.0 license unless otherwise marked.
+
+In the case of any conflict or confusion within this specification repository between the Community Specification License and the designated source code license, the terms of the Community Specification License shall apply.

--- a/governance/05-governance.md
+++ b/governance/05-governance.md
@@ -1,0 +1,51 @@
+# Community Specification Governance Policy 1.0
+
+This document provides the governance policy for specifications and other documents developed using the Community Specification process in a repository (each a "Working Group").  Each Working Group and must adhere to the requirements in this document.
+
+## 1.	Roles.
+
+Each Working Group may include the following roles. Additional roles may be adopted and documented by the Working Group.
+
+**1.1.	Maintainer.** "Maintainers" are responsible for organizing activities around developing, maintaining, and updating the specification(s) developed by the Working Group.  Maintainers are also responsible for determining consensus and coordinating appeals.  Each Working Group will designate one or more Maintainer for that Working Group.  A Working Group may select a new or additional Maintainer(s) upon Approval of the Working Group Participants.  
+
+**1.2.	Editor.**  "Editors" are responsible for ensuring that the contents of the document accurately reflect the decisions that have been made by the group, and that the specification adheres to formatting and content guidelines. Each Working Group will designate an Editor for that Working Group.  A Working Group may select a new Editor upon Approval of the Working Group Participants.
+
+**1.3.	Participants.**  "Participants" are those that have made Contributions to the Working Group subject to the Community Specification License.
+
+## 2.	Decision Making.
+
+**2.1.	Consensus-Based Decision Making.**  Working Groups make decisions through a consensus process ("Approval" or "Approved").  While the agreement of all Participants is preferred, it is not required for consensus.  Rather, the Maintainer will determine consensus based on their good faith consideration of a number of factors, including the dominant view of the Working Group Participants and nature of support and objections.  The Maintainer will document evidence of consensus in accordance with these requirements. 
+
+**2.2.	Appeal Process.**  Decisions may be appealed be via a pull request or an issue, and that appeal will be considered by the Maintainer in good faith, who will respond in writing within a reasonable time.
+
+## 3.	Ways of Working.
+
+Inspired by [ANSI's Essential Requirements for Due Process](https://share.ansi.org/Shared%20Documents/Standards%20Activities/American%20National%20Standards/Procedures,%20Guides,%20and%20Forms/2020_ANSI_Essential_Requirements.pdf), Community Specification Working Groups must adhere to consensus-based due process requirements.  These requirements apply to activities related to the development of consensus for approval, revision, reaffirmation, and withdrawal of Community Specifications.  Due process means that any person (organization, company, government agency, individual, etc.) with a direct and material interest has a right to participate by: a) expressing a position and its basis, b) having that position considered, and c) having the right to appeal. Due process allows for equity and fair play. The following constitute the minimum acceptable due process requirements for the development of consensus.
+
+**3.1.	Openness.**  Participation shall be open to all persons who are directly and materially affected by the activity in question. There shall be no undue financial barriers to participation. Voting membership on the consensus body shall not be conditional upon membership in any organization, nor unreasonably restricted on the basis of technical qualifications or other such requirements.  Membership in a Working Group's parent organization, if any, may be required.
+
+**3.2.	Lack of Dominance.**  The development process shall not be dominated by any single interest category, individual or organization. Dominance means a position or exercise of dominant authority, leadership, or influence by reason of superior leverage, strength, or representation to the exclusion of fair and equitable consideration of other viewpoints.
+
+**3.3.	Balance.**  The development process should have a balance of interests. Participants from diverse interest categories shall be sought with the objective of achieving balance.
+
+**3.4.	Coordination and Harmonization.**  Good faith efforts shall be made to resolve potential conflicts between and among deliverables developed under this Working Group and existing industry standards.
+
+**3.5.	Consideration of Views and Objections.**  Prompt consideration shall be given to the written views and objections of all Participants.
+
+**3.6.	Written procedures.**  This governance document and other materials documenting the Community Specification development process shall be available to any interested person.
+
+## 4.	Specification Development Process.  
+
+**4.1.	Pre-Draft.**  Any Participant may submit a proposed initial draft document as a candidate Draft Specification of that Working Group.  The Maintainer will designate each submission as a "Pre-Draft" document.
+
+**4.2.	Draft.**  Each Pre-Draft document of a Working Group must first be Approved to become a" Draft Specification".  Once the Working Group approves a document as a Draft Specification, the Draft Specification becomes the basis for all going forward work on that specification.
+
+**4.3.	Working Group Approval.**  Once a Working Group believes it has achieved the objectives for its specification as described in the Scope, it will Approve that Draft Specification and progress it to "Approved Specification" status. 
+
+**4.4.	Publication and Submission.**  Upon the designation of a Draft Specification as an Approved Specification, the Maintainer will publish the Approved Specification in a manner agreed upon by the Working Group Participants (i.e., Working Group Participant only location, publicly available location, Working Group maintained website, Working Group member website, etc.).  The publication of an Approved Specification in a publicly accessible manner must include the terms under which the Approved Specification is being made available under.
+
+**4.5.	Submissions to Standards Bodies.**  No Draft Specification or Approved Specification may be submitted to another standards development organization without Working group Approval. Upon reaching Approval, the Maintainer will coordinate the submission of the applicable Draft Specification or Approved Specification to another standards development organization. Working Group Participants that developed that Draft Specification or Approved Specification agree to grant the copyright rights necessary to make those submissions.
+
+## 5. Non-Confidential, Restricted Disclosure.
+
+Information disclosed in connection with any Working Group activity, including but not limited to meetings, Contributions, and submissions, is not confidential, regardless of any markings or statements to the contrary.  Notwithstanding the foregoing, if the Working Group is collaborating via a private repository, the Participants will not make any public disclosures of that information contained in that private repository without the Approval of the Working Group.  


### PR DESCRIPTION
Draft: adds the CSL 1.0 file set (governance/00-05). Spec under CSL; sample/source code under Apache-2.0 (dual license). Opening as draft for review.